### PR TITLE
Add planetary hour agreement radicality check and tests

### DIFF
--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -129,7 +129,9 @@ radicality:
   asc_too_late: 27.0    # degrees
   saturn_7th_enabled: true  # check Saturn in 7th
   via_combusta_enabled: true # check Moon in Via Combusta
-  
+  hour_agreement_enabled: false # check planetary hour agreement
+  hour_agreement_mode: "ruler"  # options: ruler, sign, triplicity
+
   via_combusta:
     libra_start: 15.0    # degrees into Libra
     scorpio_end: 15.0    # degrees into Scorpio (via combusta ends here)

--- a/backend/horary_engine/radicality.py
+++ b/backend/horary_engine/radicality.py
@@ -6,6 +6,102 @@ from horary_config import cfg
 from models import HoraryChart, Planet, Sign
 
 
+PLANET_SEQUENCE = [
+    Planet.SATURN,
+    Planet.JUPITER,
+    Planet.MARS,
+    Planet.SUN,
+    Planet.VENUS,
+    Planet.MERCURY,
+    Planet.MOON,
+]
+
+PLANETARY_DAY_RULERS = {
+    0: Planet.MOON,  # Monday
+    1: Planet.MARS,  # Tuesday
+    2: Planet.MERCURY,  # Wednesday
+    3: Planet.JUPITER,  # Thursday
+    4: Planet.VENUS,  # Friday
+    5: Planet.SATURN,  # Saturday
+    6: Planet.SUN,  # Sunday
+}
+
+
+def _sign_triplicity(sign: Sign) -> str:
+    """Return the elemental triplicity for a sign."""
+    if sign in {Sign.ARIES, Sign.LEO, Sign.SAGITTARIUS}:
+        return "fire"
+    if sign in {Sign.TAURUS, Sign.VIRGO, Sign.CAPRICORN}:
+        return "earth"
+    if sign in {Sign.GEMINI, Sign.LIBRA, Sign.AQUARIUS}:
+        return "air"
+    return "water"
+
+
+def check_planetary_hour_agreement(chart: HoraryChart, config) -> Dict[str, Any]:
+    """Check if planetary hour ruler agrees with Ascendant ruler."""
+
+    dt = chart.date_time
+    weekday = dt.weekday()
+    day_ruler = PLANETARY_DAY_RULERS.get(weekday, Planet.SUN)
+    hour_index = dt.hour
+    start_idx = PLANET_SEQUENCE.index(day_ruler)
+    hour_ruler = PLANET_SEQUENCE[(start_idx + hour_index) % 7]
+
+    asc_sign = list(Sign)[int((chart.ascendant % 360) // 30)]
+    asc_ruler = asc_sign.ruler
+
+    mode = getattr(config.radicality, "hour_agreement_mode", "ruler")
+
+    if mode == "ruler":
+        if hour_ruler == asc_ruler:
+            return {
+                "valid": True,
+                "reason": f"Planetary hour ruler {hour_ruler.value} matches Ascendant ruler",
+            }
+        return {
+            "valid": False,
+            "reason": (
+                f"Planetary hour ruler {hour_ruler.value} does not match Ascendant ruler {asc_ruler.value}"
+            ),
+        }
+
+    if mode == "sign":
+        hour_pos = chart.planets.get(hour_ruler)
+        if hour_pos and hour_pos.sign == asc_sign:
+            return {
+                "valid": True,
+                "reason": (
+                    f"Planetary hour ruler {hour_ruler.value} in Ascendant sign {asc_sign.sign_name}"
+                ),
+            }
+        return {
+            "valid": False,
+            "reason": (
+                f"Planetary hour ruler {hour_ruler.value} not in Ascendant sign {asc_sign.sign_name}"
+            ),
+        }
+
+    if mode == "triplicity":
+        hour_pos = chart.planets.get(hour_ruler)
+        if hour_pos and _sign_triplicity(hour_pos.sign) == _sign_triplicity(asc_sign):
+            return {
+                "valid": True,
+                "reason": (
+                    "Planetary hour ruler shares triplicity with Ascendant"
+                ),
+            }
+        return {
+            "valid": False,
+            "reason": (
+                "Planetary hour ruler does not share triplicity with Ascendant"
+            ),
+        }
+
+    # Unsupported mode - default to valid
+    return {"valid": True, "reason": "Unsupported hour agreement mode"}
+
+
 def check_enhanced_radicality(chart: HoraryChart, ignore_saturn_7th: bool = False) -> Dict[str, Any]:
     """Enhanced radicality checks with configuration"""
 
@@ -56,6 +152,12 @@ def check_enhanced_radicality(chart: HoraryChart, ignore_saturn_7th: bool = Fals
                     "volatile or corrupted matter"
                 ),
             }
+
+    # Planetary hour agreement (configurable)
+    if getattr(config.radicality, "hour_agreement_enabled", False):
+        hour_check = check_planetary_hour_agreement(chart, config)
+        if not hour_check["valid"]:
+            return hour_check
 
     return {
         "valid": True,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,9 @@ pytz==2023.3
 requests==2.31.0
 python-dateutil==2.8.2
 
+# YAML configuration support
+PyYAML==6.0.2
+
 # Production deployment
 gunicorn==21.2.0
 

--- a/backend/tests/test_planetary_hour_agreement.py
+++ b/backend/tests/test_planetary_hour_agreement.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import datetime
+
+# Allow importing modules from the backend package
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+from horary_config import cfg
+from horary_engine.radicality import check_enhanced_radicality
+from models import HoraryChart, Planet, Sign, PlanetPosition
+
+
+@pytest.mark.parametrize(
+    "enabled, matches, expected",
+    [
+        (True, True, True),
+        (True, False, False),
+        (False, True, True),
+        (False, False, True),
+    ],
+)
+def test_planetary_hour_agreement(monkeypatch, enabled, matches, expected):
+    config = cfg()
+    monkeypatch.setattr(config.radicality, "hour_agreement_enabled", enabled)
+    monkeypatch.setattr(config.radicality, "hour_agreement_mode", "ruler")
+
+    base_dt = datetime.datetime(2024, 9, 2, 0, 0)  # Monday
+    if matches:
+        dt = base_dt  # planetary hour ruler Moon
+        asc_sign = Sign.CANCER  # ruler Moon
+    else:
+        dt = base_dt + datetime.timedelta(hours=1)  # planetary hour ruler Saturn
+        asc_sign = Sign.ARIES  # ruler Mars
+
+    asc_degree = asc_sign.value[0] + 10  # 10 degrees into the sign
+
+    planets = {
+        Planet.MOON: PlanetPosition(Planet.MOON, 0, 0, 1, Sign.ARIES, 0),
+        Planet.SATURN: PlanetPosition(Planet.SATURN, 0, 0, 1, Sign.ARIES, 0),
+    }
+
+    chart = HoraryChart(
+        date_time=dt,
+        date_time_utc=dt,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=[],
+        houses=[0.0] * 12,
+        house_rulers={i: Planet.MARS for i in range(1, 13)},
+        ascendant=asc_degree,
+        midheaven=0.0,
+    )
+
+    result = check_enhanced_radicality(chart)
+    assert result["valid"] is expected


### PR DESCRIPTION
## Summary
- compute planetary hour ruler and compare to Ascendant with configurable modes
- gate planetary hour check behind `radicality.hour_agreement_enabled`
- exercise planetary hour agreement feature with new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e298083688324834c66253780dcf0