### PR TITLE
Add term and face reception

### DIFF
--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -159,3 +159,320 @@ retrograde:
   automatic_denial: false  # Don't automatically deny for retrograde
   dignity_penalty: -2     # Penalty for retrograde significator
   frustration_penalty: -5 # Additional penalty for retrograde frustration
+
+reception:
+  terms:
+    Aries:
+      - ruler: Jupiter
+        start: 0
+        end: 6
+      - ruler: Venus
+        start: 6
+        end: 12
+      - ruler: Mercury
+        start: 12
+        end: 20
+      - ruler: Mars
+        start: 20
+        end: 25
+      - ruler: Saturn
+        start: 25
+        end: 30
+    Taurus:
+      - ruler: Venus
+        start: 0
+        end: 8
+      - ruler: Mercury
+        start: 8
+        end: 14
+      - ruler: Jupiter
+        start: 14
+        end: 22
+      - ruler: Saturn
+        start: 22
+        end: 27
+      - ruler: Mars
+        start: 27
+        end: 30
+    Gemini:
+      - ruler: Mercury
+        start: 0
+        end: 6
+      - ruler: Jupiter
+        start: 6
+        end: 12
+      - ruler: Venus
+        start: 12
+        end: 17
+      - ruler: Mars
+        start: 17
+        end: 24
+      - ruler: Saturn
+        start: 24
+        end: 30
+    Cancer:
+      - ruler: Mars
+        start: 0
+        end: 7
+      - ruler: Venus
+        start: 7
+        end: 13
+      - ruler: Mercury
+        start: 13
+        end: 19
+      - ruler: Jupiter
+        start: 19
+        end: 26
+      - ruler: Saturn
+        start: 26
+        end: 30
+    Leo:
+      - ruler: Jupiter
+        start: 0
+        end: 6
+      - ruler: Venus
+        start: 6
+        end: 11
+      - ruler: Saturn
+        start: 11
+        end: 18
+      - ruler: Mercury
+        start: 18
+        end: 24
+      - ruler: Mars
+        start: 24
+        end: 30
+    Virgo:
+      - ruler: Mercury
+        start: 0
+        end: 7
+      - ruler: Venus
+        start: 7
+        end: 17
+      - ruler: Jupiter
+        start: 17
+        end: 21
+      - ruler: Mars
+        start: 21
+        end: 28
+      - ruler: Saturn
+        start: 28
+        end: 30
+    Libra:
+      - ruler: Saturn
+        start: 0
+        end: 6
+      - ruler: Mercury
+        start: 6
+        end: 14
+      - ruler: Jupiter
+        start: 14
+        end: 21
+      - ruler: Venus
+        start: 21
+        end: 28
+      - ruler: Mars
+        start: 28
+        end: 30
+    Scorpio:
+      - ruler: Mars
+        start: 0
+        end: 7
+      - ruler: Venus
+        start: 7
+        end: 11
+      - ruler: Mercury
+        start: 11
+        end: 19
+      - ruler: Jupiter
+        start: 19
+        end: 24
+      - ruler: Saturn
+        start: 24
+        end: 30
+    Sagittarius:
+      - ruler: Jupiter
+        start: 0
+        end: 12
+      - ruler: Venus
+        start: 12
+        end: 17
+      - ruler: Mercury
+        start: 17
+        end: 21
+      - ruler: Saturn
+        start: 21
+        end: 26
+      - ruler: Mars
+        start: 26
+        end: 30
+    Capricorn:
+      - ruler: Mercury
+        start: 0
+        end: 7
+      - ruler: Jupiter
+        start: 7
+        end: 14
+      - ruler: Venus
+        start: 14
+        end: 22
+      - ruler: Saturn
+        start: 22
+        end: 26
+      - ruler: Mars
+        start: 26
+        end: 30
+    Aquarius:
+      - ruler: Mercury
+        start: 0
+        end: 7
+      - ruler: Venus
+        start: 7
+        end: 13
+      - ruler: Jupiter
+        start: 13
+        end: 20
+      - ruler: Mars
+        start: 20
+        end: 25
+      - ruler: Saturn
+        start: 25
+        end: 30
+    Pisces:
+      - ruler: Venus
+        start: 0
+        end: 12
+      - ruler: Jupiter
+        start: 12
+        end: 16
+      - ruler: Mercury
+        start: 16
+        end: 19
+      - ruler: Mars
+        start: 19
+        end: 28
+      - ruler: Saturn
+        start: 28
+        end: 30
+
+  faces:
+    Aries:
+      - ruler: Mars
+        start: 0
+        end: 10
+      - ruler: Sun
+        start: 10
+        end: 20
+      - ruler: Venus
+        start: 20
+        end: 30
+    Taurus:
+      - ruler: Mercury
+        start: 0
+        end: 10
+      - ruler: Moon
+        start: 10
+        end: 20
+      - ruler: Saturn
+        start: 20
+        end: 30
+    Gemini:
+      - ruler: Jupiter
+        start: 0
+        end: 10
+      - ruler: Mars
+        start: 10
+        end: 20
+      - ruler: Sun
+        start: 20
+        end: 30
+    Cancer:
+      - ruler: Venus
+        start: 0
+        end: 10
+      - ruler: Mercury
+        start: 10
+        end: 20
+      - ruler: Moon
+        start: 20
+        end: 30
+    Leo:
+      - ruler: Saturn
+        start: 0
+        end: 10
+      - ruler: Jupiter
+        start: 10
+        end: 20
+      - ruler: Mars
+        start: 20
+        end: 30
+    Virgo:
+      - ruler: Sun
+        start: 0
+        end: 10
+      - ruler: Venus
+        start: 10
+        end: 20
+      - ruler: Mercury
+        start: 20
+        end: 30
+    Libra:
+      - ruler: Moon
+        start: 0
+        end: 10
+      - ruler: Saturn
+        start: 10
+        end: 20
+      - ruler: Jupiter
+        start: 20
+        end: 30
+    Scorpio:
+      - ruler: Mars
+        start: 0
+        end: 10
+      - ruler: Sun
+        start: 10
+        end: 20
+      - ruler: Venus
+        start: 20
+        end: 30
+    Sagittarius:
+      - ruler: Mercury
+        start: 0
+        end: 10
+      - ruler: Moon
+        start: 10
+        end: 20
+      - ruler: Saturn
+        start: 20
+        end: 30
+    Capricorn:
+      - ruler: Jupiter
+        start: 0
+        end: 10
+      - ruler: Mars
+        start: 10
+        end: 20
+      - ruler: Sun
+        start: 20
+        end: 30
+    Aquarius:
+      - ruler: Venus
+        start: 0
+        end: 10
+      - ruler: Mercury
+        start: 10
+        end: 20
+      - ruler: Moon
+        start: 20
+        end: 30
+    Pisces:
+      - ruler: Saturn
+        start: 0
+        end: 10
+      - ruler: Jupiter
+        start: 10
+        end: 20
+      - ruler: Mars
+        start: 20
+        end: 30

--- a/backend/horary_engine/reception.py
+++ b/backend/horary_engine/reception.py
@@ -2,6 +2,8 @@
 
 from typing import Dict, List, Tuple, Any
 
+from horary_config import cfg
+
 from models import Planet, Sign, HoraryChart
 
 
@@ -99,12 +101,41 @@ class TraditionalReceptionCalculator:
             dignities.append("exaltation")
 
         # 3. Triplicity (third strongest)
-        if self._has_triplicity_dignity(receiving_planet, received_position.sign, is_day):
+        if self._has_triplicity_dignity(
+            receiving_planet, received_position.sign, is_day
+        ):
             dignities.append("triplicity")
 
-        # TODO: Could add terms and faces for complete traditional reception
+        # Get position within sign for terms/faces
+        sign_degree = (
+            received_position.longitude - received_position.sign.start_degree
+        ) % 30
+
         # 4. Terms (Egyptian terms)
+        try:
+            terms_table = getattr(
+                cfg().reception.terms, received_position.sign.sign_name
+            )
+            for term in terms_table:
+                if term.start <= sign_degree < term.end:
+                    if Planet[term.ruler.upper()] == receiving_planet:
+                        dignities.append("term")
+                    break
+        except AttributeError:
+            pass
+
         # 5. Faces/Decans
+        try:
+            faces_table = getattr(
+                cfg().reception.faces, received_position.sign.sign_name
+            )
+            for face in faces_table:
+                if face.start <= sign_degree < face.end:
+                    if Planet[face.ruler.upper()] == receiving_planet:
+                        dignities.append("face")
+                    break
+        except AttributeError:
+            pass
 
         return dignities
 
@@ -138,6 +169,18 @@ class TraditionalReceptionCalculator:
 
         if "exaltation" in reception_1_to_2 and "exaltation" in reception_2_to_1:
             return "mutual_exaltation", {
+                "planet1_dignities": reception_1_to_2,
+                "planet2_dignities": reception_2_to_1,
+            }
+
+        if "term" in reception_1_to_2 and "term" in reception_2_to_1:
+            return "mutual_term", {
+                "planet1_dignities": reception_1_to_2,
+                "planet2_dignities": reception_2_to_1,
+            }
+
+        if "face" in reception_1_to_2 and "face" in reception_2_to_1:
+            return "mutual_face", {
                 "planet1_dignities": reception_1_to_2,
                 "planet2_dignities": reception_2_to_1,
             }
@@ -179,6 +222,10 @@ class TraditionalReceptionCalculator:
             return (
                 f"{planet1.value}↔{planet2.value} mixed reception ({p1_dignities} / {p2_dignities})"
             )
+        if reception_type == "mutual_term":
+            return f"{planet1.value}↔{planet2.value} mutual term reception"
+        if reception_type == "mutual_face":
+            return f"{planet1.value}↔{planet2.value} mutual face reception"
         if reception_type == "unilateral":
             receiving = details.get("receiving_planet")
             received = details.get("received_planet")
@@ -196,6 +243,10 @@ class TraditionalReceptionCalculator:
             return 8
         if reception_type == "mixed_reception":
             return 6
+        if reception_type == "mutual_term":
+            return 5
+        if reception_type == "mutual_face":
+            return 4
         if reception_type == "unilateral":
             dignities = details.get("dignities", [])
             if "domicile" in dignities:
@@ -204,7 +255,11 @@ class TraditionalReceptionCalculator:
                 return 4
             if "triplicity" in dignities:
                 return 3
-            return 2
+            if "term" in dignities:
+                return 2
+            if "face" in dignities:
+                return 1
+            return 1
         return 1
 
     def _calculate_house_position(self, longitude: float, houses: List[float]) -> int:

--- a/backend/tests/test_reception_terms_faces.py
+++ b/backend/tests/test_reception_terms_faces.py
@@ -1,0 +1,71 @@
+import datetime
+import importlib.util
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from models import Planet, Sign, PlanetPosition, HoraryChart
+
+# Load reception module directly to avoid heavy package imports
+spec = importlib.util.spec_from_file_location(
+    "reception", Path(__file__).resolve().parent.parent / "horary_engine" / "reception.py"
+)
+reception = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(reception)
+TraditionalReceptionCalculator = reception.TraditionalReceptionCalculator
+
+
+def make_chart(positions):
+    houses = [i * 30 for i in range(12)]
+    planets = {}
+    for planet, (sign, degree) in positions.items():
+        longitude = sign.start_degree + degree
+        planets[planet] = PlanetPosition(
+            planet=planet,
+            longitude=longitude,
+            latitude=0.0,
+            house=1,
+            sign=sign,
+            dignity_score=0,
+        )
+    now = datetime.datetime.utcnow()
+    return HoraryChart(
+        date_time=now,
+        date_time_utc=now,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=[],
+        houses=houses,
+        house_rulers={i + 1: Planet.SUN for i in range(12)},
+        ascendant=0.0,
+        midheaven=0.0,
+    )
+
+
+def test_unilateral_term_reception():
+    chart = make_chart({
+        Planet.MERCURY: (Sign.LEO, 15),
+        Planet.VENUS: (Sign.ARIES, 15),
+        Planet.SUN: (Sign.ARIES, 0),
+    })
+    calc = TraditionalReceptionCalculator()
+    res = calc.calculate_comprehensive_reception(chart, Planet.MERCURY, Planet.VENUS)
+    assert res["type"] == "unilateral"
+    assert res["details"]["receiving_planet"] == Planet.MERCURY
+    assert "term" in res["details"]["dignities"]
+    assert "term" in res["planet1_receives_planet2"]
+    assert not res["planet2_receives_planet1"]
+
+
+def test_mutual_face_reception():
+    chart = make_chart({
+        Planet.SUN: (Sign.LIBRA, 0),
+        Planet.MOON: (Sign.GEMINI, 20),
+    })
+    calc = TraditionalReceptionCalculator()
+    res = calc.calculate_comprehensive_reception(chart, Planet.SUN, Planet.MOON)
+    assert res["type"] == "mutual_face"
+    assert "face" in res["planet1_receives_planet2"]
+    assert "face" in res["planet2_receives_planet1"]


### PR DESCRIPTION
## Summary
- add term and face dignity checks from configurable tables
- classify and score mutual receptions by term or face
- document term/face tables in configuration and add tests

## Testing
- `pytest -q` *(fails: ImportError: swisseph: undefined symbol: PyUnicode_AS_DATA)*
- `pytest tests/test_reception_terms_faces.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e2cf578cc83249613422104770b67